### PR TITLE
[GTK] Pick largest monitor as device-zoom base when no primary is set

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Device.java
@@ -1121,17 +1121,41 @@ protected int getDeviceZoom() {
 }
 
 /**
- * Returns the GDK primary monitor handle, falling back to the monitor at
- * virtual coordinate (0,0) when no primary monitor is reported (e.g. on Wayland).
+ * Returns a monitor handle to use as the basis for the initial device zoom:
+ * the GDK primary monitor when one is configured, otherwise the largest
+ * monitor (Wayland has no primary), with {@code monitor_at_point(0,0)} as a
+ * final fallback.
  *
  * @noreference This method is not intended to be referenced by clients.
  */
 protected long getPrimaryMonitor(long display) {
 	long monitor = GDK.gdk_display_get_primary_monitor(display);
-	if (monitor == 0) {
-		monitor = GDK.gdk_display_get_monitor_at_point(display, 0, 0);
+	if (monitor != 0) {
+		return monitor;
 	}
-	return monitor;
+	monitor = pickLargestMonitor(display);
+	if (monitor != 0) {
+		return monitor;
+	}
+	return GDK.gdk_display_get_monitor_at_point(display, 0, 0);
+}
+
+private static long pickLargestMonitor(long display) {
+	int n = GDK.gdk_display_get_n_monitors(display);
+	long best = 0;
+	long bestArea = -1;
+	for (int i = 0; i < n; i++) {
+		long m = GDK.gdk_display_get_monitor(display, i);
+		if (m == 0) continue;
+		GdkRectangle r = new GdkRectangle();
+		GDK.gdk_monitor_get_geometry(m, r);
+		long area = (long) r.width * r.height;
+		if (area > bestArea) {
+			bestArea = area;
+			best = m;
+		}
+	}
+	return best;
 }
 
 }


### PR DESCRIPTION
Follow-up to b98f360b.
On Wayland, `gdk_display_get_primary_monitor()` always returns NULL because the protocol has no concept of a primary monitor, so the fallback in `Device.getPrimaryMonitor(long)` was just `gdk_display_get_monitor_at_point(display, 0, 0)`, which arbitrarily picks whichever output the compositor anchors at the virtual origin. That is exactly the behaviour issue #3273 was meant to fix.

This adds a Wayland-friendly middle step: when no primary is reported, pick the monitor with the largest geometry, which is a stable compositor-independent heuristic for the user's main work display and matches the X11 answer in the common case. The (0,0) fallback stays as a defensive last resort for single-monitor setups.

Scope is intentionally narrow.
SWT's GTK port still uses a single global device zoom, so this only improves the startup pick on mixed-DPI Wayland layouts; per-monitor rescaling at runtime (as Win32 already does) is the real fix and is tracked separately.
No JNI changes, no native rebuild required.