### PR TITLE
Fix UI freeze in GTK Table.setItemCount for large item counts

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -3614,7 +3614,21 @@ public void setItemCount (int count) {
 	 * used in recreateRenderers().
 	 */
 	boolean detachModel = isVirtual;
-	if (detachModel) GTK.gtk_tree_view_set_model (handle, 0);
+	/*
+	 * Detaching the model resets the selection, the focus/cursor row and the
+	 * scroll position, none of which GTK restores on reattach. Capture them
+	 * first and restore them afterwards so callers don't see those regressions.
+	 */
+	int [] selection = null;
+	int focusIndex = -1;
+	int topIndex = -1;
+	if (detachModel) {
+		selection = getSelectionIndices ();
+		TableItem focusItem = getFocusItem ();
+		if (focusItem != null) focusIndex = indexOf (focusItem);
+		topIndex = getTopIndex ();
+		GTK.gtk_tree_view_set_model (handle, 0);
+	}
 	try {
 		remove (count, itemCount - 1);
 		int length = Math.max (4, (count + 3) / 4 * 4);
@@ -3635,7 +3649,30 @@ public void setItemCount (int count) {
 			}
 		}
 	} finally {
-		if (detachModel) GTK.gtk_tree_view_set_model (handle, modelHandle);
+		if (detachModel) {
+			GTK.gtk_tree_view_set_model (handle, modelHandle);
+			if (topIndex != -1 && topIndex < itemCount) {
+				setTopIndex (topIndex);
+			}
+			if (focusIndex != -1 && focusIndex < itemCount) {
+				// selectFocusIndex() both focuses and selects the row, so undo
+				// the selection unless the focused row was actually selected.
+				selectFocusIndex (focusIndex);
+				boolean focusSelected = false;
+				if (selection != null) {
+					for (int sel : selection) {
+						if (sel == focusIndex) {
+							focusSelected = true;
+							break;
+						}
+					}
+				}
+				if (!focusSelected) deselect (focusIndex);
+			}
+			if (selection != null && selection.length > 0) {
+				select (selection);
+			}
+		}
 	}
 	if (!isVirtual) setRedraw (true);
 }

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/widgets/Table.java
@@ -3604,23 +3604,38 @@ public void setItemCount (int count) {
 	if (count == itemCount) return;
 	boolean isVirtual = (style & SWT.VIRTUAL) != 0;
 	if (!isVirtual) setRedraw (false);
-	remove (count, itemCount - 1);
-	int length = Math.max (4, (count + 3) / 4 * 4);
-	TableItem [] newItems = new TableItem [length];
-	System.arraycopy (items, 0, newItems, 0, itemCount);
-	items = newItems;
-	if (isVirtual) {
-		long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
-		if (iter == 0) error (SWT.ERROR_NO_HANDLES);
-		for (int i=itemCount; i<count; i++) {
-			GTK.gtk_list_store_append (modelHandle, iter);
+	/*
+	 * Modifying the GtkListStore while it is attached to the GtkTreeView makes
+	 * GTK emit per-row signals and update the view on every single append/remove.
+	 * For large item counts this turns setItemCount() into an O(n^2) operation
+	 * that can freeze the UI for over a second (see issue #208). Detaching the
+	 * model for the duration of the bulk update lets GTK process all the changes
+	 * in a single pass; the model is reattached afterwards. The same technique is
+	 * used in recreateRenderers().
+	 */
+	boolean detachModel = isVirtual;
+	if (detachModel) GTK.gtk_tree_view_set_model (handle, 0);
+	try {
+		remove (count, itemCount - 1);
+		int length = Math.max (4, (count + 3) / 4 * 4);
+		TableItem [] newItems = new TableItem [length];
+		System.arraycopy (items, 0, newItems, 0, itemCount);
+		items = newItems;
+		if (isVirtual) {
+			long iter = OS.g_malloc (GTK.GtkTreeIter_sizeof ());
+			if (iter == 0) error (SWT.ERROR_NO_HANDLES);
+			for (int i=itemCount; i<count; i++) {
+				GTK.gtk_list_store_append (modelHandle, iter);
+			}
+			OS.g_free (iter);
+			itemCount = count;
+		} else {
+			for (int i=itemCount; i<count; i++) {
+				new TableItem (this, SWT.NONE, i, true);
+			}
 		}
-		OS.g_free (iter);
-		itemCount = count;
-	} else {
-		for (int i=itemCount; i<count; i++) {
-			new TableItem (this, SWT.NONE, i, true);
-		}
+	} finally {
+		if (detachModel) GTK.gtk_tree_view_set_model (handle, modelHandle);
 	}
 	if (!isVirtual) setRedraw (true);
 }


### PR DESCRIPTION
## Problem

Reported in [eclipse-platform/eclipse.platform.swt#208](https://github.com/eclipse-platform/eclipse.platform.swt/issues/208): ~1.3 second UI freezes originating in `org.eclipse.swt.widgets.Table.setItemCount()` on Linux/GTK, triggered by the Git History view refreshing its (virtual) `TableViewer`.

## Root cause

`setItemCount()` mutated the `GtkListStore` while it was **still attached to the `GtkTreeView`**. GTK emits a per-row signal and updates the view on every single `gtk_list_store_append` / `gtk_list_store_remove`, so growing or shrinking the table by a large number of rows degraded to an effectively **O(n²)** operation that blocks the UI thread.

## Fix

Detach the model from the view for the duration of the bulk update and reattach it afterwards (wrapped in `try/finally`), so GTK applies all row changes in a single pass. This mirrors the technique already documented and used in `recreateRenderers()` in the same file:

```java
// In recreateRenderers():
GTK.gtk_tree_view_set_model (handle, 0);
... bulk model rebuild ...
GTK.gtk_tree_view_set_model (handle, newModel);
```

The detach is applied only for `SWT.VIRTUAL` tables (the reported and most common bulk-update path); non-virtual tables keep their existing `setRedraw(false/true)` behaviour.

## Notes for reviewers

- Java-only change — no native rebuild required.
- I could not benchmark GTK timings in the build environment; the change is validated for correctness by the cross-platform CI. A manual before/after measurement on a large virtual `Table` would be a good confirmation of the perf win.
- `Tree.setItemCount()` contains the same attached-model bulk-mutation pattern and would benefit from the same treatment; left out here to keep the fix focused on the reported widget. Happy to follow up.

Fixes https://github.com/eclipse-platform/eclipse.platform.swt/issues/208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WPzrP376SJ5gQJNyhq5jB

---
_Generated by [Claude Code](https://claude.ai/code/session_012WPzrP376SJ5gQJNyhq5jB)_